### PR TITLE
Release 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,11 @@ jobs:
       run: |
         tox
     - name: Upload coverage artifact
-      uses: actions/upload-artifact@v4.3.3
+      uses: actions/upload-artifact@v4.4.0
       with:
         name: coverage-${{ matrix.python-version }}
         path: .coverage
+        include-hidden-files: true
 
   coverage:
     name: Process test coverage

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,19 @@
+Version 0.2.0 (2024-09-30)
+- Updated testing dependencies:
+  - Bump pylint to 3.3.1
+  - Bump mypy to 1.11.2
+  - Bump pytest to 8.3.2
+  - Bump pytest-cov to 5.0.0
+  - Bump flake8 to 7.1.1
+  - Bump tox to 4.18.0
+  - Bump pre-commit to 3.7.1
+  - Bump pytest-asyncio to 0.24.0
+  - Bump setuptools to 75.1.0
+  - Bump black to 24.4.2
+- Updated dependencies:
+  - Bump dataclasses_json to 0.6.7
+  - Update yarl to ~=1.12.1
+
 Version 0.1.0 (2024-02-03)
 - Implemented mapping for Operation Modes
 - Use of dataclasses_json to handle responses easier

--- a/pygruenbeck_cloud/__version__.py
+++ b/pygruenbeck_cloud/__version__.py
@@ -1,3 +1,3 @@
 """pygruenbeck_cloud version."""
 
-__version__ = "0.1.0"  # pragma: no cover
+__version__ = "0.2.0"  # pragma: no cover

--- a/pygruenbeck_cloud/pygruenbeck_cloud.py
+++ b/pygruenbeck_cloud/pygruenbeck_cloud.py
@@ -860,6 +860,7 @@ class PyGruenbeckCloud:
 
     async def _http_request(
         self,
+        *,
         headers: dict,
         url: StrOrURL,
         data: Any = None,


### PR DESCRIPTION
Fixed yarl dependency error and updated some other dependencies.

- Updated testing dependencies:
  - Bump pylint to 3.3.1
  - Bump mypy to 1.11.2
  - Bump pytest to 8.3.2
  - Bump pytest-cov to 5.0.0
  - Bump flake8 to 7.1.1
  - Bump tox to 4.18.0
  - Bump pre-commit to 3.7.1
  - Bump pytest-asyncio to 0.24.0
  - Bump setuptools to 75.1.0
  - Bump black to 24.4.2
- Updated dependencies:
  - Bump dataclasses_json to 0.6.7
  - Update yarl to ~=1.12.1