### PR TITLE
Prepare Release 1.1.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 1.1.0 (2024-10-06)
+- Changed API Version to 2024-05-02 (Adds support for SE Models)
+
 Version 1.0.0 (2024-10-02)
 - Added missing parameter and realtime information from API
 - Added mapping for Regeneration Status, Languages and LED mode

--- a/pygruenbeck_cloud/__init__.py
+++ b/pygruenbeck_cloud/__init__.py
@@ -3,7 +3,7 @@
 # flake8: noqa
 from .pygruenbeck_cloud import PyGruenbeckCloud
 
-__version__ = "1.0.0"  # pragma: no cover
+__version__ = "1.1.0"  # pragma: no cover
 
 __all__ = [
     "PyGruenbeckCloud",

--- a/pygruenbeck_cloud/const.py
+++ b/pygruenbeck_cloud/const.py
@@ -42,7 +42,7 @@ LOGIN_REFRESH_TIME_BEFORE_EXPIRE = timedelta(minutes=10)
 # HTTP API Details
 API_SCHEME: Final = "https"
 API_HOST: Final = "prod-eu-gruenbeck-api.azurewebsites.net"
-API_VERSION: Final = "2020-08-03"
+API_VERSION: Final = "2024-05-02"
 API_GET_MG_INFOS_ENDPOINT: Final = ""  # Endpoint is empty for normal MG Infos
 API_GET_MG_INFOS_ENDPOINT_PARAMETERS: Final = "parameters"
 API_GET_MG_INFOS_ENDPOINT_SALT_MEASUREMENTS: Final = "measurements/salt"


### PR DESCRIPTION
- Changed API Version to 2024-05-02 (Adds support for SE Models)