### PR TITLE
Fix expected status codes for real time requests to support SE models

### DIFF
--- a/pygruenbeck_cloud/pygruenbeck_cloud.py
+++ b/pygruenbeck_cloud/pygruenbeck_cloud.py
@@ -807,7 +807,7 @@ class PyGruenbeckCloud:
             headers=headers,
             method=method,
             data=data,
-            expected_status_codes=[aiohttp.http.HTTPStatus.ACCEPTED],
+            expected_status_codes=[aiohttp.http.HTTPStatus.ACCEPTED, aiohttp.http.HTTPStatus.OK],
             use_cookies=use_cookies,
         )
 
@@ -847,7 +847,7 @@ class PyGruenbeckCloud:
             headers=headers,
             method=method,
             data=data,
-            expected_status_codes=[aiohttp.http.HTTPStatus.ACCEPTED],
+            expected_status_codes=[aiohttp.http.HTTPStatus.ACCEPTED, aiohttp.http.HTTPStatus.OK],
             use_cookies=use_cookies,
         )
 


### PR DESCRIPTION
Updated the `expected_status_codes` list to also accept HTTP 200 (OK) in two API request methods. This ensures better compatibility with responses that return a successful HTTP 200 status.

This PR should fix the issue https://github.com/p0l0/hagruenbeck_cloud/issues/117 for the ha integration